### PR TITLE
FIX: Update category path handling in order to use store view specific slugs

### DIFF
--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -351,13 +351,15 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         // at least, add the root category ID to the category => product relations
         $this->productCategoryIds[] = $rootCategory[MemberNames::ENTITY_ID];
 
+        $storeViewCode = $this->getValue(ColumnKeys::STORE_VIEW_CODE);
+
         // append the category => product relations found
         foreach ($this->getValue(ColumnKeys::CATEGORIES, array(), array($this, 'explode')) as $path) {
             try {
                 // try to load the category for the given path
-                $category = $this->getCategoryByPath(trim($path));
+                $category = $this->getCategoryByPath(trim($path), $storeViewCode);
                 // resolve the product's categories recursively
-                $this->resolveCategoryIds($category[MemberNames::ENTITY_ID], true, $this->getValue(ColumnKeys::STORE_VIEW_CODE));
+                $this->resolveCategoryIds($category[MemberNames::ENTITY_ID], true, $storeViewCode);
 
             } catch (\Exception $e) {
                 // query whether or not debug mode has been enabled
@@ -377,7 +379,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
             $this->categoryId = $categoryId;
 
             // prepare the attributes for each URL rewrite
-            $this->urlRewrites[$categoryId] = $this->prepareAttributes();
+            $this->urlRewrites[$categoryId] = $this->prepareAttributes($storeViewCode);
         }
     }
 
@@ -430,16 +432,18 @@ class UrlRewriteObserver extends AbstractProductImportObserver
     /**
      * Prepare the attributes of the entity that has to be persisted.
      *
+     * @param string $storeViewCode
+     *
      * @return array The prepared attributes
      */
-    protected function prepareAttributes()
+    protected function prepareAttributes($storeViewCode)
     {
 
         // load the store ID to use
         $storeId = $this->getSubject()->getRowStoreId();
 
         // load the category to create the URL rewrite for
-        $category = $this->getCategory($this->categoryId);
+        $category = $this->getCategory($this->categoryId, $storeViewCode);
 
         // initialize the values
         $metadata = $this->prepareMetadata($category);
@@ -616,24 +620,26 @@ class UrlRewriteObserver extends AbstractProductImportObserver
      * Return's the category with the passed path.
      *
      * @param string $path The path of the category to return
+     * @param string $storeViewCode The code of store view
      *
      * @return array The category
      */
-    protected function getCategoryByPath($path)
+    protected function getCategoryByPath($path, $storeViewCode = StoreViewCodes::ADMIN)
     {
-        return $this->getSubject()->getCategoryByPath($path);
+        return $this->getSubject()->getCategoryByPath($path, $storeViewCode);
     }
 
     /**
      * Return's the category with the passed ID.
      *
      * @param integer $categoryId The ID of the category to return
+     * @param string $storeViewCode The code of store view
      *
      * @return array The category data
      */
-    protected function getCategory($categoryId)
+    protected function getCategory($categoryId, $storeViewCode = StoreViewCodes::ADMIN)
     {
-        return $this->getSubject()->getCategory($categoryId);
+        return $this->getSubject()->getCategory($categoryId, $storeViewCode);
     }
 
     /**

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -357,7 +357,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
                 // try to load the category for the given path
                 $category = $this->getCategoryByPath(trim($path));
                 // resolve the product's categories recursively
-                $this->resolveCategoryIds($category[MemberNames::ENTITY_ID], true);
+                $this->resolveCategoryIds($category[MemberNames::ENTITY_ID], true, $this->getValue(ColumnKeys::STORE_VIEW_CODE));
 
             } catch (\Exception $e) {
                 // query whether or not debug mode has been enabled
@@ -388,10 +388,11 @@ class UrlRewriteObserver extends AbstractProductImportObserver
      *
      * @param integer $categoryId The ID of the category to resolve the parents
      * @param boolean $topLevel   TRUE if the passed category has top level, else FALSE
+     * @param string  $storeViewCode Store view code
      *
      * @return void
      */
-    protected function resolveCategoryIds($categoryId, $topLevel = false)
+    protected function resolveCategoryIds($categoryId, $topLevel = false, $storeViewCode = StoreViewCodes::ADMIN)
     {
 
         // return immediately if this is the absolute root node
@@ -400,7 +401,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         }
 
         // load the data of the category with the passed ID
-        $category = $this->getCategory($categoryId);
+        $category = $this->getCategory($categoryId, $storeViewCode);
 
         // query whether or not the product has already been related
         if (!in_array($categoryId, $this->productCategoryIds)) {

--- a/src/Observers/UrlRewriteUpdateObserver.php
+++ b/src/Observers/UrlRewriteUpdateObserver.php
@@ -24,6 +24,7 @@ use TechDivision\Import\Product\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\MemberNames;
 use TechDivision\Import\Product\UrlRewrite\Utils\ColumnKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\ConfigurationKeys;
+use TechDivision\Import\Utils\StoreViewCodes;
 
 /**
  * Observer that creates/updates the product's URL rewrites.
@@ -324,12 +325,13 @@ class UrlRewriteUpdateObserver extends UrlRewriteObserver
      * Return's the category with the passed ID.
      *
      * @param integer $categoryId The ID of the category to return
+     * @param string  $storeViewCode The code of an store view; Default 'admin'
      *
      * @return array The category data
      */
-    protected function getCategory($categoryId)
+    protected function getCategory($categoryId, $storeViewCode = StoreViewCodes::ADMIN)
     {
-        return $this->getSubject()->getCategory($categoryId);
+        return $this->getSubject()->getCategory($categoryId, $storeViewCode);
     }
 
     /**

--- a/src/Observers/UrlRewriteUpdateObserver.php
+++ b/src/Observers/UrlRewriteUpdateObserver.php
@@ -91,7 +91,7 @@ class UrlRewriteUpdateObserver extends UrlRewriteObserver
                     if (isset($this->urlRewrites[$metadata[UrlRewriteObserver::CATEGORY_ID]])) {
                         try {
                             // if yes, try to load the original category and OVERRIDE the default category
-                            $category = $this->getCategory($metadata[UrlRewriteObserver::CATEGORY_ID]);
+                            $category = $this->getCategory($metadata[UrlRewriteObserver::CATEGORY_ID], $this->getValue(ColumnKeys::STORE_VIEW_CODE));
                         } catch (\Exception $e) {
                             // if the old category can NOT be loaded, remove the
                             // category ID from the URL rewrites metadata


### PR DESCRIPTION
Current implementation of techdivision/import-product-url-rewrite does care about store view specific url slugs in categories. 

This fix depends on:
- https://github.com/techdivision/import-product/pull/107
- https://github.com/techdivision/import/pull/121