### PR TITLE
PAC-252 - Only generate category product rewrites if enabled in backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# TBA
+
+## Bugfixes
+
+* None
+
+## Features
+
+* PAC-252 - Only generate category product rewrites if enabled in backend
+
 # Version 24.0.0
 
 ## Bugfixes

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -405,20 +405,8 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         // load the data of the category with the passed ID
         $category = $this->getCategory($categoryId, $storeViewCode);
 
-        // query whether or not the product has already been related
-        if (!in_array($categoryId, $this->productCategoryIds)) {
-            if ($topLevel) {
-                // relate it, if the category is top level
-                $this->productCategoryIds[] = $categoryId;
-            } elseif ((integer) $category[MemberNames::IS_ANCHOR] === 1) {
-                // also relate it, if the category is not top level, but has the anchor flag set
-                $this->productCategoryIds[] = $categoryId;
-            } else {
-                $this->getSubject()
-                     ->getSystemLogger()
-                     ->debug(sprintf('Don\'t create URL rewrite for category "%s" because of missing anchor flag', $category[MemberNames::PATH]));
-            }
-        }
+        // create the product category relation for the current category
+        $this->createProductCategoryRelation($category, $topLevel);
 
         // load the root category
         $rootCategory = $this->getRootCategory();
@@ -427,6 +415,49 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         if ($rootCategory[MemberNames::ENTITY_ID] !== ($parentId = $category[MemberNames::PARENT_ID])) {
             $this->resolveCategoryIds($parentId, false);
         }
+    }
+
+    /**
+     * Adds the entity product relation if necessary.
+     *
+     * @param array   $category The category to create the relation for
+     * @param boolean $topLevel Whether or not the category has top level
+     *
+     * @return void
+     */
+    protected function createProductCategoryRelation($category, $topLevel)
+    {
+
+        // query whether or not the product has already been related
+        if (in_array($category[MemberNames::ENTITY_ID], $this->productCategoryIds)) {
+            return;
+        }
+
+        // load the backend configuration value for whether or not the catalog product rewrites should be generated
+        $generateCategoryRewrites = (bool) $this->getSubject()->getCoreConfigData(
+            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
+            true
+        );
+
+        // abort if option is set and category is not root
+        if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
+            return;
+        }
+
+        // create relation if the category is top level or has the anchor flag set
+        if ($topLevel || (integer) $category[MemberNames::IS_ANCHOR] === 1) {
+            $this->productCategoryIds[] = $category[MemberNames::ENTITY_ID];
+            return;
+        }
+
+        $this->getSubject()
+            ->getSystemLogger()
+            ->debug(
+                sprintf(
+                    'Don\'t create URL rewrite for category "%s" because of missing anchor flag',
+                    $category[MemberNames::PATH]
+                )
+            );
     }
 
     /**

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -20,9 +20,9 @@
 
 namespace TechDivision\Import\Product\UrlRewrite\Observers;
 
+use TechDivision\Import\Product\UrlRewrite\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Utils\StoreViewCodes;
 use TechDivision\Import\Product\Utils\VisibilityKeys;
-use TechDivision\Import\Product\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Product\Observers\AbstractProductImportObserver;
 use TechDivision\Import\Product\UrlRewrite\Utils\ColumnKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\MemberNames;

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -434,10 +434,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         }
 
         // load the backend configuration value for whether or not the catalog product rewrites should be generated
-        $generateCategoryRewrites = (bool) $this->getSubject()->getCoreConfigData(
-            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
-            true
-        );
+        $generateCategoryRewrites = $this->getGenerateCategoryProductRewritesOptionValue();
 
         // abort if generating product categories is disabled and category is not root
         if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
@@ -458,6 +455,19 @@ class UrlRewriteObserver extends AbstractProductImportObserver
                     $category[MemberNames::PATH]
                 )
             );
+    }
+
+    /**
+     * Returns the option value for whether or not to generate product catalog rewrites as well.
+     *
+     * @return bool
+     */
+    protected function getGenerateCategoryProductRewritesOptionValue()
+    {
+        return (bool) $this->getSubject()->getCoreConfigData(
+            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
+            true
+        );
     }
 
     /**

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -439,7 +439,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
             true
         );
 
-        // abort if option is set and category is not root
+        // abort if generating product categories is disabled and category is not root
         if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
             return;
         }

--- a/src/Utils/CoreConfigDataKeys.php
+++ b/src/Utils/CoreConfigDataKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * TechDivision\Import\Product\UrlRewrite\Utils\CoreConfigDataKeys
+ *
+ * @author    Marcus Döllerer <m.doellerer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @link      https://www.techdivision.com
+ */
+
+namespace TechDivision\Import\Product\UrlRewrite\Utils;
+
+/**
+ * Utility class containing the keys Magento uses to persist values in the "core_config_data table".
+ *
+ * @author    Marcus Döllerer <m.doellerer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/techdivision/import-product-url-rewrite
+ * @link      https://www.techdivision.com
+ */
+class CoreConfigDataKeys extends \TechDivision\Import\Product\Utils\CoreConfigDataKeys
+{
+
+    /**
+     * Name for the column 'catalog/seo/generate_category_product_rewrites'.
+     *
+     * @var string
+     */
+    const CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES = 'catalog/seo/generate_category_product_rewrites';
+}

--- a/tests/unit/Observers/UrlRewriteUpdateObserverTest.php
+++ b/tests/unit/Observers/UrlRewriteUpdateObserverTest.php
@@ -298,20 +298,13 @@ class UrlRewriteUpdateObserverTest extends TestCase
         $mockSubject->expects($this->any())
                     ->method('getRowStoreId')
                     ->willReturn($storeId = 1);
-        $mockSubject->expects($this->exactly(9))
+        $mockSubject->expects($this->any())
                     ->method('getCoreConfigData')
-                    ->withConsecutive(
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html')
-                    )
-                    ->willReturnOnConsecutiveCalls('.html', '.html', '.html', true, '.html', true, '.html', true, '.html', '.html');
+                    ->will(
+                        $this->returnCallback(function ($arg1, $arg2) {
+                            return $arg2;
+                        })
+                    );
         $mockSubject->expects($this->exactly(4))
                     ->method('getImportAdapter')
                     ->willReturn($mockImportAdapter);


### PR DESCRIPTION
With this pull request, the backend option value `catalog/seo/generate_category_product_rewrites` will be used in order to determine whether or not to generate url rewrites for all product categories or just for the default category. This change should reduce the number of unnecessarily imported product category rewrites and therefore improve performance for larger product bases with many categories.