### PR TITLE
PAC-252 - Only generate category product rewrites if enabled in backend (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Version 24.1.0
+
+## Bugfixes
+
+* None
+
+## Features
+
+* PAC-252 - Only generate category product rewrites if enabled in backend (backport)
+
 # Version 24.0.0
 
 ## Bugfixes

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
  [![License](https://img.shields.io/packagist/l/techdivision/import-product-url-rewrite.svg?style=flat-square)](https://packagist.org/packages/techdivision/import-product-url-rewrite)
  [![Build Status](https://img.shields.io/travis/techdivision/import-product-url-rewrite/master.svg?style=flat-square)](http://travis-ci.org/techdivision/import-product-url-rewrite)
  [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/techdivision/import-product-url-rewrite/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/techdivision/import-product-url-rewrite/?branch=master) [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/techdivision/import-product-url-rewrite/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/techdivision/import-product-url-rewrite/?branch=master)
- 
-Please visit the M2IF [website](https://m2if.com) for documentation and additional information
+
+Please visit the Pacemaker [website](https://pacemaker.techdivision.com) or our [documentation](https://docs.met.tdintern.de/pacemaker/1.3/) for additional information

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# M2IF - Product URL Rewrite Import
+# Pacemaker - Product URL Rewrite Import
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/techdivision/import-product-url-rewrite.svg?style=flat-square)](https://packagist.org/packages/techdivision/import-product-url-rewrite) 
  [![Total Downloads](https://img.shields.io/packagist/dt/techdivision/import-product-url-rewrite.svg?style=flat-square)](https://packagist.org/packages/techdivision/import-product-url-rewrite)

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -447,6 +447,8 @@ class UrlRewriteObserver extends AbstractProductImportObserver
             return;
         }
 
+        // log a debug messsage that the URL rewrite has not
+        // been created because of the missing anchor flag
         $this->getSubject()
             ->getSystemLogger()
             ->debug(

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -405,20 +405,8 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         // load the data of the category with the passed ID
         $category = $this->getCategory($categoryId, $storeViewCode);
 
-        // query whether or not the product has already been related
-        if (!in_array($categoryId, $this->productCategoryIds)) {
-            if ($topLevel) {
-                // relate it, if the category is top level
-                $this->productCategoryIds[] = $categoryId;
-            } elseif ((integer) $category[MemberNames::IS_ANCHOR] === 1) {
-                // also relate it, if the category is not top level, but has the anchor flag set
-                $this->productCategoryIds[] = $categoryId;
-            } else {
-                $this->getSubject()
-                     ->getSystemLogger()
-                     ->debug(sprintf('Don\'t create URL rewrite for category "%s" because of missing anchor flag', $category[MemberNames::PATH]));
-            }
-        }
+        // create the product category relation for the current category
+        $this->createProductCategoryRelation($category, $topLevel);
 
         // load the root category
         $rootCategory = $this->getRootCategory();
@@ -427,6 +415,49 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         if ($rootCategory[MemberNames::ENTITY_ID] !== ($parentId = $category[MemberNames::PARENT_ID])) {
             $this->resolveCategoryIds($parentId, false);
         }
+    }
+
+    /**
+     * Adds the entity product relation if necessary.
+     *
+     * @param array   $category The category to create the relation for
+     * @param boolean $topLevel Whether or not the category has top level
+     *
+     * @return void
+     */
+    protected function createProductCategoryRelation($category, $topLevel)
+    {
+
+        // query whether or not the product has already been related
+        if (in_array($category[MemberNames::ENTITY_ID], $this->productCategoryIds)) {
+            return;
+        }
+
+        // load the backend configuration value for whether or not the catalog product rewrites should be generated
+        $generateCategoryRewrites = (bool) $this->getSubject()->getCoreConfigData(
+            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
+            true
+        );
+
+        // abort if option is set and category is not root
+        if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
+            return;
+        }
+
+        // create relation if the category is top level or has the anchor flag set
+        if ($topLevel || (integer) $category[MemberNames::IS_ANCHOR] === 1) {
+            $this->productCategoryIds[] = $category[MemberNames::ENTITY_ID];
+            return;
+        }
+
+        $this->getSubject()
+            ->getSystemLogger()
+            ->debug(
+                sprintf(
+                    'Don\'t create URL rewrite for category "%s" because of missing anchor flag',
+                    $category[MemberNames::PATH]
+                )
+            );
     }
 
     /**

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -20,9 +20,9 @@
 
 namespace TechDivision\Import\Product\UrlRewrite\Observers;
 
+use TechDivision\Import\Product\UrlRewrite\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Utils\StoreViewCodes;
 use TechDivision\Import\Product\Utils\VisibilityKeys;
-use TechDivision\Import\Product\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Product\Observers\AbstractProductImportObserver;
 use TechDivision\Import\Product\UrlRewrite\Utils\ColumnKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\MemberNames;

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -434,10 +434,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         }
 
         // load the backend configuration value for whether or not the catalog product rewrites should be generated
-        $generateCategoryRewrites = (bool) $this->getSubject()->getCoreConfigData(
-            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
-            true
-        );
+        $generateCategoryRewrites = $this->getGenerateCategoryProductRewritesOptionValue();
 
         // abort if generating product categories is disabled and category is not root
         if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
@@ -458,6 +455,19 @@ class UrlRewriteObserver extends AbstractProductImportObserver
                     $category[MemberNames::PATH]
                 )
             );
+    }
+
+    /**
+     * Returns the option value for whether or not to generate product catalog rewrites as well.
+     *
+     * @return bool
+     */
+    protected function getGenerateCategoryProductRewritesOptionValue()
+    {
+        return (bool) $this->getSubject()->getCoreConfigData(
+            CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,
+            true
+        );
     }
 
     /**

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -439,7 +439,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
             true
         );
 
-        // abort if option is set and category is not root
+        // abort if generating product categories is disabled and category is not root
         if ($generateCategoryRewrites === false && $this->isRootCategory($category) === false) {
             return;
         }

--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -425,7 +425,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
      *
      * @return void
      */
-    protected function createProductCategoryRelation($category, $topLevel)
+    private function createProductCategoryRelation($category, $topLevel)
     {
 
         // query whether or not the product has already been related
@@ -462,7 +462,7 @@ class UrlRewriteObserver extends AbstractProductImportObserver
      *
      * @return bool
      */
-    protected function getGenerateCategoryProductRewritesOptionValue()
+    private function getGenerateCategoryProductRewritesOptionValue()
     {
         return (bool) $this->getSubject()->getCoreConfigData(
             CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES,

--- a/src/Utils/CoreConfigDataKeys.php
+++ b/src/Utils/CoreConfigDataKeys.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * TechDivision\Import\Product\UrlRewrite\Utils\CoreConfigDataKeys
+ *
+ * @author    Marcus Döllerer <m.doellerer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @link      https://www.techdivision.com
+ */
+
+namespace TechDivision\Import\Product\UrlRewrite\Utils;
+
+/**
+ * Utility class containing the keys Magento uses to persist values in the "core_config_data table".
+ *
+ * @author    Marcus Döllerer <m.doellerer@techdivision.com>
+ * @copyright 2020 TechDivision GmbH <info@techdivision.com>
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @link      https://github.com/techdivision/import-product-url-rewrite
+ * @link      https://www.techdivision.com
+ */
+class CoreConfigDataKeys extends \TechDivision\Import\Product\Utils\CoreConfigDataKeys
+{
+
+    /**
+     * Name for the column 'catalog/seo/generate_category_product_rewrites'.
+     *
+     * @var string
+     */
+    const CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES = 'catalog/seo/generate_category_product_rewrites';
+}

--- a/tests/unit/Observers/UrlRewriteObserverTest.php
+++ b/tests/unit/Observers/UrlRewriteObserverTest.php
@@ -25,10 +25,11 @@ use ReflectionClass;
 use TechDivision\Import\Utils\EntityStatus;
 use TechDivision\Import\Utils\StoreViewCodes;
 use TechDivision\Import\Product\Utils\VisibilityKeys;
-use TechDivision\Import\Product\Utils\CoreConfigDataKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\ColumnKeys;
 use TechDivision\Import\Product\UrlRewrite\Utils\MemberNames;
 use TechDivision\Import\Adapter\SerializerAwareAdapterInterface;
+use TechDivision\Import\Product\UrlRewrite\Utils\CoreConfigDataKeys;
+use TechDivision\Import\Product\UrlRewrite\Subjects\UrlRewriteSubject;
 
 /**
  * Test class for the product URL rewrite observer implementation.
@@ -75,23 +76,46 @@ class UrlRewriteObserverTest extends TestCase
         $this->observer = new UrlRewriteObserver($this->mockProductUrlRewriteProcessor);
     }
 
+    /**
+     * Create's and invokes the UrlRewriteObserver instance.
+     *
+     * @param boolean $generateCategoryProductRewrites Whether or not the configuration to generare catagory/product URL rewrites has been activated
+     * @param array   $productCategoryIds              The array with the category IDs the product has been related with
+     * @param array   $category                        The array with the categories
+     *
+     * @return void
+     */
     private function createAndInvokeObserver($generateCategoryProductRewrites = true, $productCategoryIds = [], $category = [])
     {
-        $observer = $this->getMockBuilder('TechDivision\Import\Product\UrlRewrite\Observers\UrlRewriteObserver')
+
+        // create a mock subject
+        $mockSubject = $this->getMockBuilder(UrlRewriteSubject::class)
+                            ->setMethods(array('getCoreConfigData'))
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        // mock the method to load the Magento configuration data with
+        $mockSubject->expects($this->exactly(1))
+                            ->method('getCoreConfigData')
+                            ->with(CoreConfigDataKeys::CATALOG_SEO_GENERATE_CATEGORY_PRODUCT_REWRITES)
+                            ->willReturn($generateCategoryProductRewrites);
+
+        // mock the observer
+        $observer = $this->getMockBuilder(UrlRewriteObserver::class)
             ->setConstructorArgs([$this->mockProductUrlRewriteProcessor])
-            ->setMethods(['getGenerateCategoryProductRewritesOptionValue', 'isRootCategory'])
+            ->setMethods(['getGenerateCategoryProductRewritesOptionValue', 'isRootCategory', 'getSubject'])
             ->getMock();
 
         $observer->expects($this->any())
-            ->method('getGenerateCategoryProductRewritesOptionValue')
-            ->willReturn($generateCategoryProductRewrites);
+            ->method('getSubject')
+            ->willReturn($mockSubject);
 
         $observer->expects($this->any())
             ->method('isRootCategory')
             ->willReturn(false);
 
         // prepare protected properties of observer
-        $reflection = new ReflectionClass('TechDivision\Import\Product\UrlRewrite\Observers\UrlRewriteObserver');
+        $reflection = new ReflectionClass(UrlRewriteObserver::class);
         $property = $reflection->getProperty('productCategoryIds');
         $property->setAccessible(true);
         $property->setValue($observer, $productCategoryIds);
@@ -101,9 +125,16 @@ class UrlRewriteObserverTest extends TestCase
         $method->setAccessible(true);
         $method->invoke($observer, $category, true);
 
+        // return category IDs the URL rewrites has been created for
         return $property->getValue($observer);
     }
 
+    /**
+     * Invoke a test to make sure that all categories that
+     * have been related to a product have been processed.
+     *
+     * @return void
+     */
     public function testCreateProductCategoryRelationWithChildCategoryAndSettingEnabled()
     {
 
@@ -118,9 +149,16 @@ class UrlRewriteObserverTest extends TestCase
         // create and invoke the partially mocked observer
         $productCategoryIds = $this->createAndInvokeObserver($generateCategoryProductRewrites, $productCategoryIds, $category);
 
+        // assert that all categories have been processed
         $this->assertSame($productCategoryIds, ['2', '10']);
     }
 
+    /**
+     * Invoke a test to make sure that only the root category has been
+     * processed, when the flag in the configuration has been activated.
+     *
+     * @return void
+     */
     public function testCreateProductCategoryRelationWithChildCategoryAndSettingDisabled()
     {
 
@@ -135,6 +173,7 @@ class UrlRewriteObserverTest extends TestCase
         // create and invoke the partially mocked observer
         $productCategoryIds = $this->createAndInvokeObserver($generateCategoryProductRewrites, $productCategoryIds, $category);
 
+        // assert that only the root category ID has been processed
         $this->assertSame($productCategoryIds, ['2']);
     }
 

--- a/tests/unit/Observers/UrlRewriteObserverTest.php
+++ b/tests/unit/Observers/UrlRewriteObserverTest.php
@@ -75,7 +75,7 @@ class UrlRewriteObserverTest extends TestCase
         $this->observer = new UrlRewriteObserver($this->mockProductUrlRewriteProcessor);
     }
 
-    protected function createAndInvokeObserver($generateCategoryProductRewrites = true, $productCategoryIds = [], $category = [])
+    private function createAndInvokeObserver($generateCategoryProductRewrites = true, $productCategoryIds = [], $category = [])
     {
         $observer = $this->getMockBuilder('TechDivision\Import\Product\UrlRewrite\Observers\UrlRewriteObserver')
             ->setConstructorArgs([$this->mockProductUrlRewriteProcessor])

--- a/tests/unit/Observers/UrlRewriteUpdateObserverTest.php
+++ b/tests/unit/Observers/UrlRewriteUpdateObserverTest.php
@@ -298,20 +298,13 @@ class UrlRewriteUpdateObserverTest extends TestCase
         $mockSubject->expects($this->any())
                     ->method('getRowStoreId')
                     ->willReturn($storeId = 1);
-        $mockSubject->expects($this->exactly(9))
+        $mockSubject->expects($this->any())
                     ->method('getCoreConfigData')
-                    ->withConsecutive(
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html'),
-                        array(CoreConfigDataKeys::CATALOG_SEO_SAVE_REWRITES_HISTORY, true),
-                        array(CoreConfigDataKeys::CATALOG_SEO_PRODUCT_URL_SUFFIX, '.html')
-                    )
-                    ->willReturnOnConsecutiveCalls('.html', '.html', '.html', true, '.html', true, '.html', true, '.html', '.html');
+                    ->will(
+                        $this->returnCallback(function ($arg1, $arg2) {
+                            return $arg2;
+                        })
+                    );
         $mockSubject->expects($this->exactly(4))
                     ->method('getImportAdapter')
                     ->willReturn($mockImportAdapter);


### PR DESCRIPTION
Backports functionality from PAC-252 (Pacemaker 4.0)