### PR TITLE
Abort if category is not a child of the root category

### DIFF
--- a/src/Observers/UrlRewriteObserver.php
+++ b/src/Observers/UrlRewriteObserver.php
@@ -405,6 +405,11 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         // load the data of the category with the passed ID
         $category = $this->getCategory($categoryId, $storeViewCode);
 
+        // if the category is not a child of the root category we have to skip it
+        if (!$this->isChildOfRootCategory($category)) {
+            return;
+        }
+
         // create the product category relation for the current category
         $this->createProductCategoryRelation($category, $topLevel);
 
@@ -415,6 +420,24 @@ class UrlRewriteObserver extends AbstractProductImportObserver
         if ($rootCategory[MemberNames::ENTITY_ID] !== ($parentId = $category[MemberNames::PARENT_ID])) {
             $this->resolveCategoryIds($parentId, false);
         }
+    }
+
+    /**
+     * Check if category is a child of the root category
+     *
+     * @param array $category The category to check
+     *
+     * @return bool
+     */
+    protected function isChildOfRootCategory($category)
+    {
+        // split the path into its segments
+        $categoryPathParts = explode('/', $category[MemberNames::PATH]);
+
+        // load the root category
+        $rootCategory = $this->getRootCategory();
+
+        return $categoryPathParts[1] === $rootCategory[MemberNames::ENTITY_ID];
     }
 
     /**


### PR DESCRIPTION
## Description
Importing a simple product into two websites with different category roots will cause an error, this is because it will try to generate a url rewrite for the root category of the other store since it's not recognized as one (it's trying to access url path but root categories do not have one). This PR fixes this issue.

## Steps to reproduce
1. Create two websites with different category roots
2. Import a simple product and assign it to both websites and a category of each root

## Expected result
The product is imported into each category with according url rewrites.

## Actual result
The import fails due to missing url path of the one root category.